### PR TITLE
add configure helper to log library; add test.

### DIFF
--- a/log.go
+++ b/log.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 )
 
@@ -117,4 +118,27 @@ func (log *Log) write(level Level, args ...interface{}) {
 
 func (level Level) String() string {
 	return levelStrings[level]
+}
+
+func Configure(logLevel, appName string, writer io.Writer) *Log {
+	// Log levels
+	logLevelFinal := Debug
+	switch strings.ToLower(logLevel) {
+	case "fatal":
+		logLevelFinal = Fatal
+	case "error":
+		logLevelFinal = Error
+	case "warning":
+		logLevelFinal = Warning
+	case "notice":
+		logLevelFinal = Notice
+	case "info":
+		logLevelFinal = Info
+	case "debug":
+	default:
+		fmt.Printf("%s_LOGLEVEL not specified, defaulting to DEBUG\n", strings.ToUpper(appName))
+	}
+
+	logger := New(writer, logLevelFinal)
+	return logger
 }

--- a/log_test.go
+++ b/log_test.go
@@ -232,6 +232,16 @@ func TestLogging(t *testing.T) {
 			Expect(string(m.Written)).To(ContainSubstring("Custom: [ERROR] -- [test message]"))
 		})
 	})
+
+	g.Describe("Initialization", func() {
+		g.It("should be properly initialized with Configure", func() {
+			m := &mockwriter.MockWriter{}
+			configuredLogger := Configure("DEBUG", "appname", m)
+			Expect(configuredLogger.threshold).To(Equal(Debug))
+			configuredLogger = Configure("Fatal", "nameOfApp", m)
+			Expect(configuredLogger.threshold).To(Equal(Fatal))
+		})
+	})
 }
 
 type CustomFormat struct {


### PR DESCRIPTION
adds a new helper method called Configure, which takes care of getting the loglevel from a string and then initializing the logger object.

I'm kinda on the fence about the log message (requiring the appname); part of me feels its a bit too application specific; but logging there shouldn't be problematic.

original ticket:
https://jira.monsooncommerce.com/browse/MST-2179