### PR TITLE
giving a little time between final log message and exit in a fatal, s…

### DIFF
--- a/log.go
+++ b/log.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 )
 
 type Level int8
@@ -108,6 +109,8 @@ func (log *Log) Errorf(format string, args ...interface{}) {
 
 func (log *Log) Fatal(args ...interface{}) {
 	log.write(Fatal, args...)
+	// give any downstream writers a little time to clear before exiting
+	<-time.After(10 * time.Millisecond)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
…o downstream writers can have some time to clear